### PR TITLE
change VPC peering to gateway id

### DIFF
--- a/terraform/aws-vpc.tf
+++ b/terraform/aws-vpc.tf
@@ -67,5 +67,5 @@ resource "aws_vpn_connection_route" "azure" {
 resource "aws_route" "azureroute" {
   route_table_id            = "${aws_vpc.vpc1.main_route_table_id}"
   destination_cidr_block    = "${azurerm_subnet.subnet.address_prefix}"
-  vpc_peering_connection_id = "${aws_vpn_gateway.vpn_gw.id}"
+  gateway_id                = "${aws_vpn_gateway.vpn_gw.id}"
 }


### PR DESCRIPTION
When setting up azure routes in aws, it should point to vpn gateway instead of vpc peering.

```tf
resource "aws_route" "azureroute" {
  ...
    gateway_id  = "${aws_vpn_gateway.vpn_gw.id}"
} 
```
otherwise I get the following error:
`Error creating route: InvalidVpcPeeringConnectionId.Malformed: Invalid id: "vgw-..." (expecting "pcx-...")`